### PR TITLE
Rename isRunning to is_running? and always return false when false

### DIFF
--- a/lib/browserstack/local.rb
+++ b/lib/browserstack/local.rb
@@ -101,7 +101,7 @@ class Local
     end
   end
 
-  def running?
+  def is_running?
     !! (!@pid.nil? && Process.kill(0, @pid)) rescue false
   end
 

--- a/lib/browserstack/local.rb
+++ b/lib/browserstack/local.rb
@@ -101,8 +101,8 @@ class Local
     end
   end
 
-  def isRunning
-    return true if (!@pid.nil? && Process.kill(0, @pid)) rescue false
+  def running?
+    !! (!@pid.nil? && Process.kill(0, @pid)) rescue false
   end
 
   def stop

--- a/test/browserstack-local-test.rb
+++ b/test/browserstack-local-test.rb
@@ -15,7 +15,7 @@ class BrowserStackLocalTest < Minitest::Test
 
   def test_is_running
     @bs_local.start
-    assert_equal true, @bs_local.isRunning
+    assert_equal true, @bs_local.is_running
   end
 
   def test_multiple_binary

--- a/test/browserstack-local-test.rb
+++ b/test/browserstack-local-test.rb
@@ -15,7 +15,7 @@ class BrowserStackLocalTest < Minitest::Test
 
   def test_is_running
     @bs_local.start
-    assert_equal true, @bs_local.is_running
+    assert_equal true, @bs_local.is_running?
   end
 
   def test_multiple_binary


### PR DESCRIPTION
In Ruby snake case is preferred to camel case. Also, using `?` for booleans. The `!!` will always return `false` instead of some empty value when it is not running. It also allows be_running (or something like that) on rspec.
