### PR TITLE
Enable certificate verification on downloads

### DIFF
--- a/lib/browserstack/localbinary.rb
+++ b/lib/browserstack/localbinary.rb
@@ -6,7 +6,7 @@ require 'tmpdir'
 require 'browserstack/localexception'
 
 module BrowserStack
-  
+
 class LocalBinary
   def initialize
     host_os = RbConfig::CONFIG['host_os']
@@ -39,7 +39,7 @@ class LocalBinary
     binary_path = File.join(dest_parent_dir, "BrowserStackLocal#{".exe" if @windows}")
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
     res = http.get(uri.path)
     file = open(binary_path, 'wb')


### PR DESCRIPTION
Disabling TLS server certificate verification undermines the security of HTTPS
(ie, one might as well use HTTP) and is considered extremely bad practice:

* https://mislav.net/2013/07/ruby-openssl/
* https://brakemanscanner.org/docs/warning_types/ssl_verification_bypass/

Looks like it's been there since the initial release, so probably an
oversight?