### PR TITLE
Adds -localIdentifier to stop command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ bs_local_args = { "key" => "<browserstack-accesskey>" , "forcelocal" => "true"}
 ```
 
 #### Proxy
-To use a proxy for local testing - 
+To use a proxy for local testing -  
 
 * proxyHost: Hostname/IP of proxy, remaining proxy options are ignored if this option is absent
 * proxyPort: Port for the proxy, defaults to 3128 when -proxyHost is used

--- a/README.md
+++ b/README.md
@@ -34,40 +34,40 @@ bs_local.stop
 
 ## Arguments
 
-Apart from the key, all other BrowserStack Local modifiers are optional. For the full list of modifiers, refer [BrowserStack Local modifiers](https://www.browserstack.com/local-testing#modifiers). For examples, refer below -  
+Apart from the key, all other BrowserStack Local modifiers are optional. For the full list of modifiers, refer [BrowserStack Local modifiers](https://www.browserstack.com/local-testing#modifiers). For examples, refer below -
 
 #### Verbose Logging
-To enable verbose logging - 
+To enable verbose logging -
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "v" => "true"}
 ```
 
 #### Folder Testing
-To test local folder rather internal server, provide path to folder as value of this option - 
+To test local folder rather internal server, provide path to folder as value of this option -
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "f" => "/my/awesome/folder"}
 ```
 
-#### Force Start 
-To kill other running Browserstack Local instances - 
+#### Force Start
+To kill other running Browserstack Local instances -
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "force" => "true"}
 ```
 
 #### Only Automate
-To disable local testing for Live and Screenshots, and enable only Automate - 
+To disable local testing for Live and Screenshots, and enable only Automate -
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "onlyAutomate" => "true"}
 ```
 
 #### Force Local
-To route all traffic via local(your) machine - 
+To route all traffic via local(your) machine -
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "forcelocal" => "true"}
 ```
 
 #### Proxy
-To use a proxy for local testing -  
+To use a proxy for local testing -
 
 * proxyHost: Hostname/IP of proxy, remaining proxy options are ignored if this option is absent
 * proxyPort: Port for the proxy, defaults to 3128 when -proxyHost is used
@@ -79,7 +79,7 @@ bs_local_args = { "key" => "<browserstack-accesskey>", "proxyHost" => "127.0.0.1
 ```
 
 #### Local Identifier
-If doing simultaneous multiple local testing connections, set this uniquely for different processes - 
+If doing simultaneous multiple local testing connections, set this uniquely for different processes -
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "localIdentifier" => "randomstring"}
 ```
@@ -95,8 +95,8 @@ bs_local_args = { "key" => "<browserstack-accesskey>" , "binarypath" => "/browse
 ```
 
 #### Logfile
-To save the logs to the file while running with the '-v' argument, you can specify the path of the file. By default the logs are saved in the local.log file in the present woring directory. 
-To specify the path to file where the logs will be saved - 
+To save the logs to the file while running with the '-v' argument, you can specify the path of the file. By default the logs are saved in the local.log file in the present woring directory.
+To specify the path to file where the logs will be saved -
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "v" => "true", "logfile" => "/browserstack/logs.txt"}
 ```
@@ -107,7 +107,7 @@ bs_local_args = { "key" => "<browserstack-accesskey>" , "v" => "true", "logfile"
 
 To build gem, `rake build`.
 
-To run the test suite run, `rake test`.
+To run the test suite run, `BROWSERSTACK_ACCESS_KEY=<your_access_key> rake test`.
 
 ### Reporting bugs
 

--- a/README.md
+++ b/README.md
@@ -34,40 +34,40 @@ bs_local.stop
 
 ## Arguments
 
-Apart from the key, all other BrowserStack Local modifiers are optional. For the full list of modifiers, refer [BrowserStack Local modifiers](https://www.browserstack.com/local-testing#modifiers). For examples, refer below -
+Apart from the key, all other BrowserStack Local modifiers are optional. For the full list of modifiers, refer [BrowserStack Local modifiers](https://www.browserstack.com/local-testing#modifiers). For examples, refer below -  
 
 #### Verbose Logging
-To enable verbose logging -
+To enable verbose logging - 
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "v" => "true"}
 ```
 
 #### Folder Testing
-To test local folder rather internal server, provide path to folder as value of this option -
+To test local folder rather internal server, provide path to folder as value of this option - 
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "f" => "/my/awesome/folder"}
 ```
 
-#### Force Start
-To kill other running Browserstack Local instances -
+#### Force Start 
+To kill other running Browserstack Local instances - 
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "force" => "true"}
 ```
 
 #### Only Automate
-To disable local testing for Live and Screenshots, and enable only Automate -
+To disable local testing for Live and Screenshots, and enable only Automate - 
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "onlyAutomate" => "true"}
 ```
 
 #### Force Local
-To route all traffic via local(your) machine -
+To route all traffic via local(your) machine - 
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "forcelocal" => "true"}
 ```
 
 #### Proxy
-To use a proxy for local testing -
+To use a proxy for local testing - 
 
 * proxyHost: Hostname/IP of proxy, remaining proxy options are ignored if this option is absent
 * proxyPort: Port for the proxy, defaults to 3128 when -proxyHost is used
@@ -79,7 +79,7 @@ bs_local_args = { "key" => "<browserstack-accesskey>", "proxyHost" => "127.0.0.1
 ```
 
 #### Local Identifier
-If doing simultaneous multiple local testing connections, set this uniquely for different processes -
+If doing simultaneous multiple local testing connections, set this uniquely for different processes - 
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "localIdentifier" => "randomstring"}
 ```
@@ -95,8 +95,8 @@ bs_local_args = { "key" => "<browserstack-accesskey>" , "binarypath" => "/browse
 ```
 
 #### Logfile
-To save the logs to the file while running with the '-v' argument, you can specify the path of the file. By default the logs are saved in the local.log file in the present woring directory.
-To specify the path to file where the logs will be saved -
+To save the logs to the file while running with the '-v' argument, you can specify the path of the file. By default the logs are saved in the local.log file in the present woring directory. 
+To specify the path to file where the logs will be saved - 
 ```
 bs_local_args = { "key" => "<browserstack-accesskey>" , "v" => "true", "logfile" => "/browserstack/logs.txt"}
 ```

--- a/lib/browserstack/local.rb
+++ b/lib/browserstack/local.rb
@@ -4,161 +4,163 @@ require 'json'
 
 module BrowserStack
 
-class Local
-  attr_reader :pid
+  class Local
+    attr_reader :pid
 
-  def initialize(key = ENV["BROWSERSTACK_ACCESS_KEY"])
-    @key = key
-    @user_arguments = []
-    @logfile = File.join(Dir.pwd, "local.log")
-    @is_windows = RbConfig::CONFIG['host_os'].match(/mswin|msys|mingw|cygwin|bccwin|wince|emc|win32/)
-    @exec = @is_windows ? "call" : "exec";
-  end
+    def initialize(key = ENV["BROWSERSTACK_ACCESS_KEY"])
+      @key = key
+      @user_arguments = []
+      @logfile = File.join(Dir.pwd, "local.log")
+      @is_windows = RbConfig::CONFIG['host_os'].match(/mswin|msys|mingw|cygwin|bccwin|wince|emc|win32/)
+      @exec = @is_windows ? "call" : "exec";
+    end
 
-  def add_args(key, value=nil)
-    if key == "key"
-      @key = value
-    elsif key == "v" && value.to_s != "false"
-      @verbose_flag = "-vvv"
-    elsif key == "force" && value.to_s != "false"
-      @force_flag = "-force"
-    elsif key == "only" && value.to_s != "false"
-      @only_flag = "-only"
-    elsif key == "onlyAutomate" && value.to_s != "false"
-      @only_automate_flag = "-onlyAutomate"
-    elsif key == "forcelocal" && value.to_s != "false"
-      @force_local_flag = "-forcelocal"
-    elsif key == "localIdentifier"
-      @local_identifier_flag = value
-    elsif key == "f"
-      @folder_flag = "-f"
-      @folder_path = value
-    elsif key == "proxyHost"
-      @proxy_host = value
-    elsif key == "proxyPort"
-      @proxy_port = value
-    elsif key == "proxyUser"
-      @proxy_user = value
-    elsif key == "proxyPass"
-      @proxy_pass = value
-    elsif key == "hosts"
-      @hosts = value
-    elsif key == "logfile"
-      @logfile = value
-    elsif key == "binarypath"
-      @binary_path = value
-    elsif key == "forceproxy" && value.to_s != "false"
-      @force_proxy_flag = "-forceproxy"
-    else
-      if value.to_s.downcase.eql?("true")
-        @user_arguments << "-#{key}"
+    def add_args(key, value=nil)
+      if key == "key"
+        @key = value
+      elsif key == "v" && value.to_s != "false"
+        @verbose_flag = "-vvv"
+      elsif key == "force" && value.to_s != "false"
+        @force_flag = "-force"
+      elsif key == "only" && value.to_s != "false"
+        @only_flag = "-only"
+      elsif key == "onlyAutomate" && value.to_s != "false"
+        @only_automate_flag = "-onlyAutomate"
+      elsif key == "forcelocal" && value.to_s != "false"
+        @force_local_flag = "-forcelocal"
+      elsif key == "localIdentifier"
+        @local_identifier_flag = value
+      elsif key == "f"
+        @folder_flag = "-f"
+        @folder_path = value
+      elsif key == "proxyHost"
+        @proxy_host = value
+      elsif key == "proxyPort"
+        @proxy_port = value
+      elsif key == "proxyUser"
+        @proxy_user = value
+      elsif key == "proxyPass"
+        @proxy_pass = value
+      elsif key == "hosts"
+        @hosts = value
+      elsif key == "logfile"
+        @logfile = value
+      elsif key == "binarypath"
+        @binary_path = value
+      elsif key == "forceproxy" && value.to_s != "false"
+        @force_proxy_flag = "-forceproxy"
       else
-        @user_arguments += ["-#{key}", value]
+        if value.to_s.downcase.eql?("true")
+          @user_arguments << "-#{key}"
+        else
+          @user_arguments += ["-#{key}", value]
+        end
       end
     end
-  end
 
-  def start(options = {})
-    options.each_pair do |key, value|
-      self.add_args(key, value)
-    end
+    def start(options = {})
+      options.each_pair do |key, value|
+        self.add_args(key, value)
+      end
 
-    @binary_path = if @binary_path.nil?
-        BrowserStack::LocalBinary.new.binary_path
+      @binary_path = if @binary_path.nil?
+                       BrowserStack::LocalBinary.new.binary_path
+                     else
+                       @binary_path
+                     end
+
+      if @is_windows
+        system("echo > #{@logfile}")
       else
-        @binary_path
-      end
-    
-    if @is_windows
-      system("echo > #{@logfile}")
-    else
-      system("echo '' > '#{@logfile}'")
-    end
-
-    if defined? spawn
-      @process = IO.popen(start_command_args)
-    else
-      @process = IO.popen(start_command)
-    end
-
-    while true
-      begin
-        line = @process.readline
-      rescue EOFError => e
-        sleep 1
-        next
+        system("echo '' > '#{@logfile}'")
       end
 
-      data = JSON.parse(line) rescue {"message" => "Unable to parse daemon mode JSON output"}
-      if data['state'].to_s != "connected"
-        @process.close
-        raise BrowserStack::LocalException.new(data["message"]["message"])
-        return
+      if defined? spawn
+        @process = IO.popen(start_command_args)
       else
-        @pid = data["pid"]
-        break
+        @process = IO.popen(start_command)
+      end
+
+      while true
+        begin
+          line = @process.readline
+        rescue EOFError => e
+          sleep 1
+          next
+        end
+
+        data = JSON.parse(line) rescue {"message" => "Unable to parse daemon mode JSON output"}
+        if data['state'].to_s != "connected"
+          @process.close
+          raise BrowserStack::LocalException.new(data["message"]["message"])
+          return
+        else
+          @pid = data["pid"]
+          break
+        end
       end
     end
-  end
 
-  def isRunning
-    return true if (!@pid.nil? && Process.kill(0, @pid)) rescue false
-  end
-
-  def stop
-    return if @pid.nil?
-    @process.close
-    if defined? spawn
-      @process = IO.popen(stop_command_args)
-    else
-      @process = IO.popen(stop_command)
+    def isRunning
+      return true if (!@pid.nil? && Process.kill(0, @pid)) rescue false
     end
-    @process.close
-    @pid = nil
-  end
 
-  def command
-    start_command
-  end
+    def stop
+      return if @pid.nil?
+      @process.close
+      if defined? spawn
+        @process = IO.popen(stop_command_args)
+      else
+        @process = IO.popen(stop_command)
+      end
+      @process.close
+      @pid = nil
+    end
 
-  def start_command
-    cmd = "#{@binary_path} -d start -logFile '#{@logfile}' #{@folder_flag} #{@key} #{@folder_path} #{@force_local_flag}"
-    cmd += " -localIdentifier #{@local_identifier_flag}" if @local_identifier_flag
-    cmd += " #{@only_flag} #{@only_automate_flag}"
-    cmd += " -proxyHost #{@proxy_host}" if @proxy_host
-    cmd += " -proxyPort #{@proxy_port}" if @proxy_port
-    cmd += " -proxyUser #{@proxy_user}" if @proxy_user
-    cmd += " -proxyPass #{@proxy_pass}" if @proxy_pass
-    cmd += " #{@force_proxy_flag} #{@force_flag} #{@verbose_flag} #{@hosts} #{@user_arguments.join(" ")} 2>&1"
-    cmd.strip
-  end
+    def command
+      start_command
+    end
 
-  def start_command_args
-    args = [@binary_path, "-d", "start", "-logFile", @logfile, @key, @folder_flag, @folder_path, @force_local_flag]
-    args += ["-localIdentifier", @local_identifier_flag] if @local_identifier_flag
-    args += [@only_flag, @only_automate_flag]
-    args += ["-proxyHost", @proxy_host] if @proxy_host
-    args += ["-proxyPort", @proxy_port] if @proxy_port
-    args += ["-proxyUser", @proxy_user] if @proxy_user
-    args += ["-proxyPass", @proxy_pass] if @proxy_pass
-    args += [@force_proxy_flag, @force_flag, @verbose_flag, @hosts]
-    args += @user_arguments
+    def start_command
+      cmd = "#{@binary_path} -d start -logFile '#{@logfile}' #{@folder_flag} #{@key} #{@folder_path} #{@force_local_flag}"
+      cmd += " -localIdentifier #{@local_identifier_flag}" if @local_identifier_flag
+      cmd += " #{@only_flag} #{@only_automate_flag}"
+      cmd += " -proxyHost #{@proxy_host}" if @proxy_host
+      cmd += " -proxyPort #{@proxy_port}" if @proxy_port
+      cmd += " -proxyUser #{@proxy_user}" if @proxy_user
+      cmd += " -proxyPass #{@proxy_pass}" if @proxy_pass
+      cmd += " #{@force_proxy_flag} #{@force_flag} #{@verbose_flag} #{@hosts} #{@user_arguments.join(" ")} 2>&1"
+      cmd.strip
+    end
 
-    args = args.select {|a| a.to_s != "" }
-    args.push(:err => [:child, :out])
-    args
-  end
+    def start_command_args
+      args = [@binary_path, "-d", "start", "-logFile", @logfile, @key, @folder_flag, @folder_path, @force_local_flag]
+      args += ["-localIdentifier", @local_identifier_flag] if @local_identifier_flag
+      args += [@only_flag, @only_automate_flag]
+      args += ["-proxyHost", @proxy_host] if @proxy_host
+      args += ["-proxyPort", @proxy_port] if @proxy_port
+      args += ["-proxyUser", @proxy_user] if @proxy_user
+      args += ["-proxyPass", @proxy_pass] if @proxy_pass
+      args += [@force_proxy_flag, @force_flag, @verbose_flag, @hosts]
+      args += @user_arguments
 
-  def stop_command
-    "#{@binary_path} -d stop #{@local_identifier_flag}".strip
-  end
+      args = args.select {|a| a.to_s != "" }
+      args.push(:err => [:child, :out])
+      args
+    end
 
-  def stop_command_args
-    args = ["#{@binary_path}", "-d", "stop", "#{@local_identifier_flag}"]
-    args = args.select {|a| a.to_s != "" }
-    args.push(:err => [:child, :out])
-    args
+    def stop_command
+      cmd = "#{@binary_path} -d stop"
+      cmd += " -localIdentifier #{@local_identifier_flag}" if @local_identifier_flag
+      cmd.strip
+    end
+
+    def stop_command_args
+      args = ["#{@binary_path}", "-d", "stop"]
+      args += ["-localIdentifier", @local_identifier_flag] if @local_identifier_flag
+      args.push(:err => [:child, :out])
+      args
+    end
   end
-end
 
 end

--- a/lib/browserstack/local.rb
+++ b/lib/browserstack/local.rb
@@ -102,7 +102,7 @@ class Local
   end
 
   def isRunning
-    return true if (!@pid.nil? && Process.kill(0, @pid)) rescue false
+    return true if (!@pid.nil? && Process.kill(0, @pid)) ensure false
   end
 
   def stop

--- a/lib/browserstack/local.rb
+++ b/lib/browserstack/local.rb
@@ -4,163 +4,163 @@ require 'json'
 
 module BrowserStack
 
-  class Local
-    attr_reader :pid
+class Local
+  attr_reader :pid
 
-    def initialize(key = ENV["BROWSERSTACK_ACCESS_KEY"])
-      @key = key
-      @user_arguments = []
-      @logfile = File.join(Dir.pwd, "local.log")
-      @is_windows = RbConfig::CONFIG['host_os'].match(/mswin|msys|mingw|cygwin|bccwin|wince|emc|win32/)
-      @exec = @is_windows ? "call" : "exec";
-    end
+  def initialize(key = ENV["BROWSERSTACK_ACCESS_KEY"])
+    @key = key
+    @user_arguments = []
+    @logfile = File.join(Dir.pwd, "local.log")
+    @is_windows = RbConfig::CONFIG['host_os'].match(/mswin|msys|mingw|cygwin|bccwin|wince|emc|win32/)
+    @exec = @is_windows ? "call" : "exec";
+  end
 
-    def add_args(key, value=nil)
-      if key == "key"
-        @key = value
-      elsif key == "v" && value.to_s != "false"
-        @verbose_flag = "-vvv"
-      elsif key == "force" && value.to_s != "false"
-        @force_flag = "-force"
-      elsif key == "only" && value.to_s != "false"
-        @only_flag = "-only"
-      elsif key == "onlyAutomate" && value.to_s != "false"
-        @only_automate_flag = "-onlyAutomate"
-      elsif key == "forcelocal" && value.to_s != "false"
-        @force_local_flag = "-forcelocal"
-      elsif key == "localIdentifier"
-        @local_identifier_flag = value
-      elsif key == "f"
-        @folder_flag = "-f"
-        @folder_path = value
-      elsif key == "proxyHost"
-        @proxy_host = value
-      elsif key == "proxyPort"
-        @proxy_port = value
-      elsif key == "proxyUser"
-        @proxy_user = value
-      elsif key == "proxyPass"
-        @proxy_pass = value
-      elsif key == "hosts"
-        @hosts = value
-      elsif key == "logfile"
-        @logfile = value
-      elsif key == "binarypath"
-        @binary_path = value
-      elsif key == "forceproxy" && value.to_s != "false"
-        @force_proxy_flag = "-forceproxy"
+  def add_args(key, value=nil)
+    if key == "key"
+      @key = value
+    elsif key == "v" && value.to_s != "false"
+      @verbose_flag = "-vvv"
+    elsif key == "force" && value.to_s != "false"
+      @force_flag = "-force"
+    elsif key == "only" && value.to_s != "false"
+      @only_flag = "-only"
+    elsif key == "onlyAutomate" && value.to_s != "false"
+      @only_automate_flag = "-onlyAutomate"
+    elsif key == "forcelocal" && value.to_s != "false"
+      @force_local_flag = "-forcelocal"
+    elsif key == "localIdentifier"
+      @local_identifier_flag = value
+    elsif key == "f"
+      @folder_flag = "-f"
+      @folder_path = value
+    elsif key == "proxyHost"
+      @proxy_host = value
+    elsif key == "proxyPort"
+      @proxy_port = value
+    elsif key == "proxyUser"
+      @proxy_user = value
+    elsif key == "proxyPass"
+      @proxy_pass = value
+    elsif key == "hosts"
+      @hosts = value
+    elsif key == "logfile"
+      @logfile = value
+    elsif key == "binarypath"
+      @binary_path = value
+    elsif key == "forceproxy" && value.to_s != "false"
+      @force_proxy_flag = "-forceproxy"
+    else
+      if value.to_s.downcase.eql?("true")
+        @user_arguments << "-#{key}"
       else
-        if value.to_s.downcase.eql?("true")
-          @user_arguments << "-#{key}"
-        else
-          @user_arguments += ["-#{key}", value]
-        end
+        @user_arguments += ["-#{key}", value]
       end
-    end
-
-    def start(options = {})
-      options.each_pair do |key, value|
-        self.add_args(key, value)
-      end
-
-      @binary_path = if @binary_path.nil?
-                       BrowserStack::LocalBinary.new.binary_path
-                     else
-                       @binary_path
-                     end
-
-      if @is_windows
-        system("echo > #{@logfile}")
-      else
-        system("echo '' > '#{@logfile}'")
-      end
-
-      if defined? spawn
-        @process = IO.popen(start_command_args)
-      else
-        @process = IO.popen(start_command)
-      end
-
-      while true
-        begin
-          line = @process.readline
-        rescue EOFError => e
-          sleep 1
-          next
-        end
-
-        data = JSON.parse(line) rescue {"message" => "Unable to parse daemon mode JSON output"}
-        if data['state'].to_s != "connected"
-          @process.close
-          raise BrowserStack::LocalException.new(data["message"]["message"])
-          return
-        else
-          @pid = data["pid"]
-          break
-        end
-      end
-    end
-
-    def isRunning
-      return true if (!@pid.nil? && Process.kill(0, @pid)) rescue false
-    end
-
-    def stop
-      return if @pid.nil?
-      @process.close
-      if defined? spawn
-        @process = IO.popen(stop_command_args)
-      else
-        @process = IO.popen(stop_command)
-      end
-      @process.close
-      @pid = nil
-    end
-
-    def command
-      start_command
-    end
-
-    def start_command
-      cmd = "#{@binary_path} -d start -logFile '#{@logfile}' #{@folder_flag} #{@key} #{@folder_path} #{@force_local_flag}"
-      cmd += " -localIdentifier #{@local_identifier_flag}" if @local_identifier_flag
-      cmd += " #{@only_flag} #{@only_automate_flag}"
-      cmd += " -proxyHost #{@proxy_host}" if @proxy_host
-      cmd += " -proxyPort #{@proxy_port}" if @proxy_port
-      cmd += " -proxyUser #{@proxy_user}" if @proxy_user
-      cmd += " -proxyPass #{@proxy_pass}" if @proxy_pass
-      cmd += " #{@force_proxy_flag} #{@force_flag} #{@verbose_flag} #{@hosts} #{@user_arguments.join(" ")} 2>&1"
-      cmd.strip
-    end
-
-    def start_command_args
-      args = [@binary_path, "-d", "start", "-logFile", @logfile, @key, @folder_flag, @folder_path, @force_local_flag]
-      args += ["-localIdentifier", @local_identifier_flag] if @local_identifier_flag
-      args += [@only_flag, @only_automate_flag]
-      args += ["-proxyHost", @proxy_host] if @proxy_host
-      args += ["-proxyPort", @proxy_port] if @proxy_port
-      args += ["-proxyUser", @proxy_user] if @proxy_user
-      args += ["-proxyPass", @proxy_pass] if @proxy_pass
-      args += [@force_proxy_flag, @force_flag, @verbose_flag, @hosts]
-      args += @user_arguments
-
-      args = args.select {|a| a.to_s != "" }
-      args.push(:err => [:child, :out])
-      args
-    end
-
-    def stop_command
-      cmd = "#{@binary_path} -d stop"
-      cmd += " -localIdentifier #{@local_identifier_flag}" if @local_identifier_flag
-      cmd.strip
-    end
-
-    def stop_command_args
-      args = ["#{@binary_path}", "-d", "stop"]
-      args += ["-localIdentifier", @local_identifier_flag] if @local_identifier_flag
-      args.push(:err => [:child, :out])
-      args
     end
   end
+
+  def start(options = {})
+    options.each_pair do |key, value|
+      self.add_args(key, value)
+    end
+
+    @binary_path = if @binary_path.nil?
+        BrowserStack::LocalBinary.new.binary_path
+      else
+        @binary_path
+      end
+
+    if @is_windows
+      system("echo > #{@logfile}")
+    else
+      system("echo '' > '#{@logfile}'")
+    end
+
+    if defined? spawn
+      @process = IO.popen(start_command_args)
+    else
+      @process = IO.popen(start_command)
+    end
+
+    while true
+      begin
+        line = @process.readline
+      rescue EOFError => e
+        sleep 1
+        next
+      end
+
+      data = JSON.parse(line) rescue {"message" => "Unable to parse daemon mode JSON output"}
+      if data['state'].to_s != "connected"
+        @process.close
+        raise BrowserStack::LocalException.new(data["message"]["message"])
+        return
+      else
+        @pid = data["pid"]
+        break
+      end
+    end
+  end
+
+  def isRunning
+    return true if (!@pid.nil? && Process.kill(0, @pid)) rescue false
+  end
+
+  def stop
+    return if @pid.nil?
+    @process.close
+    if defined? spawn
+      @process = IO.popen(stop_command_args)
+    else
+      @process = IO.popen(stop_command)
+    end
+    @process.close
+    @pid = nil
+  end
+
+  def command
+    start_command
+  end
+
+  def start_command
+    cmd = "#{@binary_path} -d start -logFile '#{@logfile}' #{@folder_flag} #{@key} #{@folder_path} #{@force_local_flag}"
+    cmd += " -localIdentifier #{@local_identifier_flag}" if @local_identifier_flag
+    cmd += " #{@only_flag} #{@only_automate_flag}"
+    cmd += " -proxyHost #{@proxy_host}" if @proxy_host
+    cmd += " -proxyPort #{@proxy_port}" if @proxy_port
+    cmd += " -proxyUser #{@proxy_user}" if @proxy_user
+    cmd += " -proxyPass #{@proxy_pass}" if @proxy_pass
+    cmd += " #{@force_proxy_flag} #{@force_flag} #{@verbose_flag} #{@hosts} #{@user_arguments.join(" ")} 2>&1"
+    cmd.strip
+  end
+
+  def start_command_args
+    args = [@binary_path, "-d", "start", "-logFile", @logfile, @key, @folder_flag, @folder_path, @force_local_flag]
+    args += ["-localIdentifier", @local_identifier_flag] if @local_identifier_flag
+    args += [@only_flag, @only_automate_flag]
+    args += ["-proxyHost", @proxy_host] if @proxy_host
+    args += ["-proxyPort", @proxy_port] if @proxy_port
+    args += ["-proxyUser", @proxy_user] if @proxy_user
+    args += ["-proxyPass", @proxy_pass] if @proxy_pass
+    args += [@force_proxy_flag, @force_flag, @verbose_flag, @hosts]
+    args += @user_arguments
+
+    args = args.select {|a| a.to_s != "" }
+    args.push(:err => [:child, :out])
+    args
+  end
+
+  def stop_command
+    cmd = "#{@binary_path} -d stop"
+    cmd += " -localIdentifier #{@local_identifier_flag}" if @local_identifier_flag
+    cmd.strip
+  end
+
+  def stop_command_args
+    args = ["#{@binary_path}", "-d", "stop"]
+    args += ["-localIdentifier", @local_identifier_flag] if @local_identifier_flag
+    args.push(:err => [:child, :out])
+    args
+  end
+end
 
 end

--- a/lib/browserstack/local.rb
+++ b/lib/browserstack/local.rb
@@ -104,7 +104,7 @@ class Local
   def isRunning
     begin
       (!@pid.nil? && Process.kill(0, @pid)) ? true : false
-    ensure
+    rescue
       false
     end
   end

--- a/lib/browserstack/local.rb
+++ b/lib/browserstack/local.rb
@@ -102,7 +102,11 @@ class Local
   end
 
   def isRunning
-    return true if (!@pid.nil? && Process.kill(0, @pid)) ensure false
+    begin
+      (!@pid.nil? && Process.kill(0, @pid)) ? true : false
+    ensure
+      false
+    end
   end
 
   def stop

--- a/lib/browserstack/local.rb
+++ b/lib/browserstack/local.rb
@@ -68,7 +68,7 @@ class Local
       else
         @binary_path
       end
-
+    
     if @is_windows
       system("echo > #{@logfile}")
     else

--- a/test/browserstack-local-test.rb
+++ b/test/browserstack-local-test.rb
@@ -39,6 +39,11 @@ class BrowserStackLocalTest < Minitest::Test
     assert_equal false, bs_local_by_ID.isRunning
   end
 
+  def test_isRunning_stopped
+    @bs_local.instance_variable_set(:@pid,nil)
+    assert_equal false, @bs_local.isRunning
+  end
+
   def test_enable_verbose
     @bs_local.add_args('v')
     assert_match /\-v/, @bs_local.command

--- a/test/browserstack-local-test.rb
+++ b/test/browserstack-local-test.rb
@@ -28,6 +28,17 @@ class BrowserStackLocalTest < Minitest::Test
     File.delete(second_log_file)
   end
 
+  def test_localId_independence
+    @bs_local.start
+    bs_local_by_ID = BrowserStack::Local.new
+    bs_local_by_ID.start({'localIdentifier' => "uniqueID"})
+    assert_equal true, @bs_local.isRunning
+    assert_equal true, bs_local_by_ID.isRunning
+    bs_local_by_ID.stop
+    assert_equal true, @bs_local.isRunning
+    assert_equal false, bs_local_by_ID.isRunning
+  end
+
   def test_enable_verbose
     @bs_local.add_args('v')
     assert_match /\-v/, @bs_local.command

--- a/test/browserstack-local-test.rb
+++ b/test/browserstack-local-test.rb
@@ -44,6 +44,12 @@ class BrowserStackLocalTest < Minitest::Test
     assert_equal false, @bs_local.isRunning
   end
 
+  def test_isRunning_crashed
+    @bs_local.instance_variable_set(:@pid,1000000000) # probably non-existant pid
+    assert_equal false, @bs_local.isRunning
+    @bs_local.instance_variable_set(:@pid,nil)
+  end
+
   def test_enable_verbose
     @bs_local.add_args('v')
     assert_match /\-v/, @bs_local.command


### PR DESCRIPTION
I was seeing a bug:
If I have multiple BrowserStackLocal tunnels running with a localIdentifier and stop any one of them, all tunnels get closed.

This pull request adds a test for that behavior, and adds a localIdentifier to the stop command. 

As part of the testing, I also changed the functioning of Local#isRunning. This previously returned `nil` if the process had been stopped (@pid was nil) It now returns false. 

This passes tests on my machine, but there may be cases that are not covered on other OS or ruby version. 