### PR TITLE
rewrite BrowserStackLocal spawning to be better

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 gem "minitest"
 gem "rake"
 gem "json"
+gemspec
+
+gem "rspec-core", "~> 3.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,30 @@
-GEM
-  remote: http://rubygems.org/
+PATH
+  remote: .
   specs:
-    json (1.8.3)
-    minitest (5.8.4)
-    rake (12.3.3)
+    browserstack-local (1.4.3)
+      subprocess (~> 1.5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    json (2.7.1)
+    minitest (5.22.2)
+    rake (13.1.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.0)
+    subprocess (1.5.6)
 
 PLATFORMS
+  arm64-darwin-23
   ruby
 
 DEPENDENCIES
+  browserstack-local!
   json
   minitest
   rake
+  rspec-core (~> 3.13)
 
 BUNDLED WITH
-   1.11.2
+   2.5.5

--- a/browserstack-local.gemspec
+++ b/browserstack-local.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |s|
   s.authors     = ["BrowserStack"]
   s.email       = 'support@browserstack.com'
   s.files       = ["lib/browserstack/local.rb", "lib/browserstack/localbinary.rb", "lib/browserstack/localexception.rb"]
-  s.homepage    =
-    'http://rubygems.org/gems/browserstack-local'
-  s.license       = 'MIT'
+  s.homepage    = 'http://rubygems.org/gems/browserstack-local'
+  s.license     = 'MIT'
+  s.add_dependency "subprocess", "~> 1.5"
 end
 


### PR DESCRIPTION
Right now, the spawning uses `IO.popen` and has a bunch of workarounds to support Ruby 1.8. This is pretty bad.

Ruby 1.8 has been EOL for more than 10 years. I don't think we need to support it any more.

This rewrites the process spawning to use Stripe's excellent [subprocess](https://github.com/stripe/subprocess) gem. It also adds a startup timeout, because right now if the `BrowserStackLocal` binary hangs for some reason, the entire program is just stuck on a `.readline` call. It also calls `.wait` on the child process after dæmonization succeeds, because otherwise you end up with an un-reaped defunct process sitting around forever.